### PR TITLE
WIP: GitHub token

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.6.0 (unreleased)
+++++++++++++++++++
+
+- Refactored the code for easier testing
+- Added Django modult to be informed when Django bugs are fixed
+
 0.5.0 (2016-11-06)
 ++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '__pycache__' -exec rm -rf {} +
 
 lint: ## check style with flake8
-	flake8 --exclude=".tox,docs,build" .
+	flake8 --exclude=".tox,docs,build,tests/package/umbrella" .
 
 test: ## run tests quickly with the default Python
 	./runtests

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ Caveats and Gotchas
 - Raincoat does not run files (either your files or the package file). Package files are parsed and the AST is analyzed.
 - If for any reason, several code objects are identically named in the file you analyze, there's no guarantee you'll get any specific one.
 - The Django module uses the public GitHub API and does a few calls. This should not be a concern most of the time, but you may experience rate-limiting issues if Raincoat is launched from an IP that does a lot of calls to the GitHub API (e.g. Travis). In this case, from your Travis settings, set the environment variable ``RAINCOAT_GITHUB_TOKEN`` to ``username:github_token``, ``github_token being a token generated `here <https://github.com/settings/tokens>`_ with all checkboxes unchecked.
+- So few people use Raincoat for now that you should expect a few bumps down the road. This being said, fire issues and pull requetes at will and I'll do my best to answer them in a timely manner.
 
 
 Todos

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ Caveats and Gotchas
 - You may realize that raincoat works best if you can use some kind of pip cache.
 - Raincoat does not run files (either your files or the package file). Package files are parsed and the AST is analyzed.
 - If for any reason, several code objects are identically named in the file you analyze, there's no guarantee you'll get any specific one.
+- The Django module uses the public GitHub API and does a few calls. This should not be a concern most of the time, but you may experience rate-limiting issues if Raincoat is launched from an IP that does a lot of calls to the GitHub API (e.g. Travis). In this case, from your Travis settings, set the environment variable ``RAINCOAT_GITHUB_TOKEN`` to ``username:github_token``, ``github_token being a token generated `here <https://github.com/settings/tokens>`_ with all checkboxes unchecked.
 
 
 Todos

--- a/acceptance_tests/test_full_chain.py
+++ b/acceptance_tests/test_full_chain.py
@@ -1,3 +1,6 @@
+import pytest
+import traceback
+
 from raincoat import main
 from raincoat import __version__
 
@@ -9,12 +12,16 @@ def test_full_chain(cli_runner):
     """
     result = cli_runner.invoke(main, ["--path=acceptance_tests/test_project"])
 
+    if result.exception and not isinstance(result.exception, SystemExit):
+        traceback.print_exception(*result.exc_info)
+        pytest.fail()
+
     details = ("raincoat == 0.1.4 vs {} "
                "@ raincoat/_acceptance_test.py:use_umbrella "
                "(from acceptance_tests/test_project/__init__.py:2)").format(
                     __version__)
 
-    print(result.output)
+    print(result.output, )
 
     assert details in result.output
     assert "_acceptance_test.py:Umbrella.open" in result.output

--- a/acceptance_tests/test_full_chain.py
+++ b/acceptance_tests/test_full_chain.py
@@ -26,4 +26,4 @@ def test_full_chain(cli_runner):
     assert "+        action(umbrella)" in result.output
 
     assert "27754" not in result.output
-    assert "Ticket #26976 has been merged in Django" in result.output
+    assert "Ticket #25981 has been merged in Django" in result.output

--- a/acceptance_tests/test_project/__init__.py
+++ b/acceptance_tests/test_project/__init__.py
@@ -3,7 +3,7 @@ def simple_function():
     # Raincoat: pypi package: raincoat==0.1.4 path: raincoat/_acceptance_test.py element: Umbrella.open  # noqa
     # Raincoat: pypi package: raincoat==0.1.4 path: raincoat/_acceptance_test.py element: Umbrella  # noqa
     # Raincoat: pypi package: raincoat==0.1.4 path: raincoat/_acceptance_test.py # noqa
-    # Raincoat: django ticket: #26976
+    # Raincoat: django ticket: #25981
     # Raincoat: django ticket: #27754
     pass
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -71,7 +71,22 @@ def test_current_version(mocker):
 
 def test_latest_version(mocker):
     get = mocker.patch("requests.get")
-    get.return_value.json.return_value = {"info": {"version": "1.0.1"}}
+    get.return_value.json.return_value = {
+        "releases": {"1.0.0": None, "1.0.1": None}}
+    assert source.get_current_or_latest_version("fr2csv") == (False, "1.0.1")
+
+
+def test_latest_version_no_prerelease(mocker):
+    get = mocker.patch("requests.get")
+    get.return_value.json.return_value = {
+        "releases": {"1.0.1": None, "1.0.2a1": None}}
+    assert source.get_current_or_latest_version("fr2csv") == (False, "1.0.1")
+
+
+def test_latest_version_invalid(mocker):
+    get = mocker.patch("requests.get")
+    get.return_value.json.return_value = {
+        "releases": {"1.0.1": None, "1.0.2rc1": None}}
     assert source.get_current_or_latest_version("fr2csv") == (False, "1.0.1")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     {py27,py34,py35}-{unit,acceptance}-tests,linters
 
 [testenv]
-passenv = COVERAGE
+passenv = COVERAGE RAINCOAT_GITHUB_TOKEN
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/raincoat
     acceptance: ACCEPTANCE=1


### PR DESCRIPTION
Should fix the broken master ( :( )
3 different problems fixed here :
- We need a GitHub API token to use the github api on travis because of rate limiting
- It seems Django releases packages on PyPI without tagging the same version on Git. I've "solved" it by restricting to stable version, for now. We'll see if there's a better alternative.
- I forgot the changelog on the previous PR.