### PR TITLE
Match plugins are now defined through Entry points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tests: ## run tests quickly with the default Python
 	pytest tests/
 
 acceptance-tests: ## Launch acceptance tests (full integration tests without mocks)
-	pytest acceptance_tests/
+	python acceptance_tests/test_full_chain.py
 
 coverage: ## run tests quickly with the default Python
 	pytest --cov --cov-report xml --cov-report term --cov-report html tests/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean-pyc clean-build docs help lint test test-all coverage release sdist acceptance-tests
+.PHONY: help install clean clean-pyc clean-build docs tests acceptance-tests coverage lint docs release
 .DEFAULT_GOAL := help
 
 # Launch "make" or "make help" for details on every target

--- a/acceptance_tests/test_full_chain.py
+++ b/acceptance_tests/test_full_chain.py
@@ -1,48 +1,57 @@
-import pytest
 import traceback
 
-from raincoat import main
+import sh
+
 from raincoat import __version__
 
 
-def test_full_chain(cli_runner):
+def main():
     """
     Note that this test is excluded from coverage because coverage should be
     for unit tests.
     """
-    result = cli_runner.invoke(main, ["--exclude=*ignored*",
-                                      "acceptance_tests/test_project"])
 
-    if result.exception and not isinstance(result.exception, SystemExit):
-        traceback.print_exception(*result.exc_info)
-        pytest.fail()
+    result = sh.raincoat(
+        "acceptance_tests/test_project", exclude="*ignored*",
+        _ok_code=1)
 
+    output = result.stdout.decode("utf-8")
+    try:
+        check_output(output)
+    except AssertionError:
+        print("Full output:\n", output)
+        raise
+
+    print("Ok")
+
+
+def check_output(output):
     details = ("raincoat == 0.1.4 vs {} "
                "@ raincoat/_acceptance_test.py:use_umbrella "
                "(from acceptance_tests/test_project/__init__.py:7)").format(
                     __version__)
 
-    # Most of the time, this is useful for debugging and the
-    # output is captured by pytest when the test passes anyway.
-    print(result.output)
-
-    assert details in result.output
-    assert "_acceptance_test.py:Umbrella.open" in result.output
+    assert details in output
+    assert "_acceptance_test.py:Umbrella.open" in output
     # space left intentionally at the end to not match the previous line
-    assert "_acceptance_test.py:Umbrella " in result.output
-    assert "_acceptance_test.py:whole module" in result.output
+    assert "_acceptance_test.py:Umbrella " in output
+    assert "_acceptance_test.py:whole module" in output
 
-    assert "-        umbrella.keep_over_me()" in result.output
-    assert "+        action(umbrella)" in result.output
+    assert "-        umbrella.keep_over_me()" in output
+    assert "+        action(umbrella)" in output
 
-    assert "ignored" not in result.output
+    assert "ignored" not in output
 
-    assert "27754" not in result.output
-    assert "Ticket #25981 has been merged in Django" in result.output
+    assert "27754" not in output
+    assert "Ticket #25981 has been merged in Django" in output
 
-    assert "novafloss/raincoat@a35df1d vs master branch" in result.output
+    assert "novafloss/raincoat@a35df1d vs master branch" in output
 
     assert ("non_existant does not exist in raincoat/_acceptance_test.py"
-            in result.output)
+            in output)
 
-    assert "raincoat/non_existant.py does not exist" in result.output
+    assert "raincoat/non_existant.py does not exist" in output
+
+
+if __name__ == '__main__':
+    main()

--- a/raincoat/match/django.py
+++ b/raincoat/match/django.py
@@ -102,7 +102,6 @@ class DjangoChecker(object):
 
 class DjangoMatch(Match):
     checker = DjangoChecker
-    match_type = "django"
     ticket_regex = re.compile(r'^#?(\d+)$')
 
     def __init__(self, filename, lineno, ticket):

--- a/raincoat/match/pygithub.py
+++ b/raincoat/match/pygithub.py
@@ -66,4 +66,3 @@ class PyGithubMatch(PythonMatch):
                 element=self.element or "whole module"))
 
     checker = PyGithubChecker
-    match_type = "pygithub"

--- a/raincoat/match/pypi.py
+++ b/raincoat/match/pypi.py
@@ -70,4 +70,3 @@ class PyPIMatch(PythonMatch):
                 element=self.element or "whole module"))
 
     checker = PyPIChecker
-    match_type = "pypi"

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,10 @@ install_requires =
 [options.entry_points]
 console_scripts =
 	raincoat = raincoat:main
+raincoat.match =
+	pypi = raincoat.match.pypi:PyPIMatch
+	django = raincoat.match.django:DjangoMatch
+	pygithub = raincoat.match.pygithub:PyGithubMatch
 
 [options.extras_require]
 dev =

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -1,7 +1,18 @@
+import pytest
+
 from raincoat.glue import raincoat
 
 
-def test_raincoat(mocker, match, match_module):
+@pytest.fixture
+def match_class(match, mocker):
+    mocker.patch("raincoat.match.match_types", {"pypi": match.__class__})
+    orig, match.__class__.match_type = match.__class__.match_type, "pypi"
+    yield
+    match.__class__.match_type = orig
+
+
+def test_raincoat(mocker, match, match_module, match_class):
+    match.__class__.match_type = "pypi"
     mocker.patch("raincoat.grep.find_in_dir",
                  return_value=[match, match_module])
     check_matches = mocker.patch("raincoat.glue.check_matches",

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -1,12 +1,17 @@
 import io
 import tempfile
+import pytest
 
 import six
 
 from raincoat import grep
 
+@pytest.fixture
+def match_class(match, mocker):
+    mocker.patch("raincoat.match.match_types", {"pypi": match.__class__})
 
-def test_string_normal():
+
+def test_string_normal(match_class):
     matches = list(grep.find_in_string("""
         # Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py element: foo
     """, filename="foo/bar"))
@@ -22,7 +27,7 @@ def test_string_normal():
     assert match.filename == "foo/bar"
 
 
-def test_string_normal_whole_module():
+def test_string_normal_whole_module(match_class):
     matches = list(grep.find_in_string("""
         # Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py
     """, filename="foo/bar"))
@@ -52,7 +57,7 @@ def test_empty():
     assert len(matches) == 0
 
 
-def test_find_in_file():
+def test_find_in_file(match_class):
     with tempfile.NamedTemporaryFile("w+") as handler:
         handler.write("""
             # Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py element: foo
@@ -62,7 +67,7 @@ def test_find_in_file():
         assert len(matches) == 1
 
 
-def test_find_in_file_oneliner():
+def test_find_in_file_oneliner(match_class):
     with tempfile.NamedTemporaryFile("w+") as handler:
         handler.write('''# Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py element: foo''')  # noqa
         handler.seek(0)
@@ -70,7 +75,7 @@ def test_find_in_file_oneliner():
         assert len(matches) == 1
 
 
-def test_find_in_file_with_comment():
+def test_find_in_file_with_comment(match_class):
     with tempfile.NamedTemporaryFile("w+") as handler:
         handler.write('''# Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py element: foo  # noqa''')  # noqa
         handler.seek(0)
@@ -170,7 +175,7 @@ def test_list_python_files_exclude_file_wildcard(mocker):
 
 
 # Full chain test
-def test_find_in_dir(mocker):
+def test_find_in_dir(mocker, match_class):
     open_responses = iter([
         ("c.py", io.StringIO(
             six.u('''# Raincoat: pypi package: BLA==1.2.3 path: yo/yeah.py element: foo'''))),  # noqa


### PR DESCRIPTION
This allows external contributors to code their own plugins outside of the scope of the project. Well i'm still <1.0.0, so I'm not guaranteing any kind of API stability, but I'll give a hand if anyone wants to help.

Ok this is absolutely just because I wanted to have fun coding it :D

BTW, the acceptance tests are now a raw python script because I wanted to limit black magic as much as possible in this part.